### PR TITLE
Add steps to prepare Git state before deploying Modal app

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,6 +27,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install modal
 
+      - name: Prepare Git State
+        run: |
+          git reset --hard HEAD
+          git clean -fd
+
       - name: Deploy Modal App
         run: |
           modal deploy modal_app.py


### PR DESCRIPTION
This pull request introduces a minor update to the CI/CD workflow configuration. The change ensures a clean and consistent Git state before deploying the Modal app.

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R30-R34): Added a new step, "Prepare Git State," to reset the Git repository to the latest commit and remove untracked files and directories.